### PR TITLE
Update Matsim version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<!-- <matsim.version>12.0</matsim.version> -->
 
 		<!-- smapshot release -->
-		<matsim.version>14.0-PR1583</matsim.version>
+		<matsim.version>14.0-PR1723</matsim.version>
 
 		<!-- weekly release -->
 		<!--<matsim.version>13.0-2021w05-SNAPSHOT</matsim.version>-->

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<!-- <matsim.version>12.0</matsim.version> -->
 
 		<!-- smapshot release -->
-		<matsim.version>14.0-PR1723</matsim.version>
+		<matsim.version>14.0-PR1746</matsim.version>
 
 		<!-- weekly release -->
 		<!--<matsim.version>13.0-2021w05-SNAPSHOT</matsim.version>-->

--- a/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRoute.java
+++ b/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRoute.java
@@ -30,6 +30,7 @@ import org.matsim.core.replanning.PlanStrategy;
 import org.matsim.core.replanning.PlanStrategyImpl.Builder;
 import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.router.TripRouter;
+import org.matsim.core.utils.timing.TimeInterpretation;
 import org.matsim.facilities.ActivityFacilities;
 
 public class ChangeSingleTripModeAndRoute implements Provider<PlanStrategy> {
@@ -38,11 +39,12 @@ public class ChangeSingleTripModeAndRoute implements Provider<PlanStrategy> {
 	@Inject private ChangeModeConfigGroup changeModeConfigGroup;
 	@Inject private ActivityFacilities facilities;
 	@Inject private Provider<TripRouter> tripRouterProvider;
+	@Inject private TimeInterpretation timeInterpretation;
 
 	@Override
 	public PlanStrategy get() {
 		Builder builder = new Builder(new RandomPlanSelector<Plan,Person>()) ;
-		builder.addStrategyModule(new ChangeSingleTripModeAndRouteModule(facilities, tripRouterProvider, globalConfigGroup, changeModeConfigGroup));
+		builder.addStrategyModule(new ChangeSingleTripModeAndRouteModule(facilities, tripRouterProvider, globalConfigGroup, changeModeConfigGroup, timeInterpretation));
 		return builder.build() ;
 	}
 

--- a/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRouteModule.java
+++ b/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRouteModule.java
@@ -29,6 +29,7 @@ import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.population.algorithms.PlanAlgorithm;
 import org.matsim.core.replanning.modules.AbstractMultithreadedModule;
 import org.matsim.core.router.TripRouter;
+import org.matsim.core.utils.timing.TimeInterpretation;
 import org.matsim.facilities.ActivityFacilities;
 
 /**
@@ -38,17 +39,19 @@ import org.matsim.facilities.ActivityFacilities;
  * @author mrieser
  */
 public class ChangeSingleTripModeAndRouteModule extends AbstractMultithreadedModule {
-	
+
 	private ActivityFacilities facilities;
 
 	private final Provider<TripRouter> tripRouterProvider;
 	private final ChangeModeConfigGroup changeModeConfigGroup;
+	private final TimeInterpretation timeInterpretation;
 
-	public ChangeSingleTripModeAndRouteModule(ActivityFacilities facilities, Provider<TripRouter> tripRouterProvider, GlobalConfigGroup globalConfigGroup, ChangeModeConfigGroup changeModeConfigGroup) {
+	public ChangeSingleTripModeAndRouteModule(ActivityFacilities facilities, Provider<TripRouter> tripRouterProvider, GlobalConfigGroup globalConfigGroup, ChangeModeConfigGroup changeModeConfigGroup, TimeInterpretation timeInterpretation) {
 		super(globalConfigGroup);
 		this.facilities = facilities;
 		this.tripRouterProvider = tripRouterProvider;
 		this.changeModeConfigGroup = changeModeConfigGroup;
+		this.timeInterpretation = timeInterpretation;
 	}
 
 	@Override
@@ -57,8 +60,8 @@ public class ChangeSingleTripModeAndRouteModule extends AbstractMultithreadedMod
 					tripRouterProvider.get(),
 					facilities,
 					MatsimRandom.getLocalInstance(),
-					changeModeConfigGroup
-					);
+					changeModeConfigGroup,
+					timeInterpretation);
 	}
 
 }

--- a/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripPlanRouter.java
+++ b/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripPlanRouter.java
@@ -34,6 +34,7 @@ import org.matsim.core.router.PlanRouter;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripStructureUtils;
 import org.matsim.core.router.TripStructureUtils.Trip;
+import org.matsim.core.utils.timing.TimeInterpretation;
 import org.matsim.facilities.ActivityFacilities;
 import org.matsim.facilities.FacilitiesUtils;
 import org.matsim.vehicles.Vehicle;
@@ -47,6 +48,7 @@ import org.matsim.vehicles.Vehicle;
  */
 public class RandomSingleTripPlanRouter implements PlanAlgorithm, PersonAlgorithm {
 	private final Random rnd;
+	private TimeInterpretation timeInterpretation;
 	private final TripRouter tripRouter;
 	private final ActivityFacilities facilities;
 
@@ -60,10 +62,12 @@ public class RandomSingleTripPlanRouter implements PlanAlgorithm, PersonAlgorith
 	public RandomSingleTripPlanRouter(
 			final TripRouter tripRouter,
 			final ActivityFacilities facilities,
-			final Random rnd) {
+			final Random rnd,
+			TimeInterpretation timeInterpretation) {
 		this.tripRouter = tripRouter;
 		this.facilities = facilities;
-		this.rnd = rnd;		
+		this.rnd = rnd;
+		this.timeInterpretation = timeInterpretation;
 	}
 
 	/**
@@ -71,8 +75,8 @@ public class RandomSingleTripPlanRouter implements PlanAlgorithm, PersonAlgorith
 	 */
 	public RandomSingleTripPlanRouter(
 			final TripRouter routingHandler,
-			final Random rnd) {
-		this( routingHandler, null , rnd);
+			final Random rnd, TimeInterpretation timeInterpretation) {
+		this( routingHandler, null , rnd, timeInterpretation);
 	}
 
 	@Override
@@ -88,9 +92,10 @@ public class RandomSingleTripPlanRouter implements PlanAlgorithm, PersonAlgorith
 							TripStructureUtils.identifyMainMode( oldTrip.getTripElements() ),
 							FacilitiesUtils.toFacility( oldTrip.getOriginActivity(), facilities ),
 							FacilitiesUtils.toFacility( oldTrip.getDestinationActivity(), facilities ),
-							PlanRouter.calcEndOfActivity( oldTrip.getOriginActivity() , plan, tripRouter.getConfig() ),
-							plan.getPerson() );
-						
+							timeInterpretation.decideOnActivityEndTimeAlongPlan( oldTrip.getOriginActivity() , plan).seconds(),
+							plan.getPerson(),
+							oldTrip.getTripAttributes()); //not sure whether this should be oldTrip.getOriginActivity().getAttributes()
+
 			putVehicleFromOldTripIntoNewTripIfMeaningful(oldTrip, newTrip);
 			TripRouter.insertTrip(
 					plan, 

--- a/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripReRoute.java
+++ b/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripReRoute.java
@@ -26,6 +26,7 @@ import org.matsim.core.replanning.PlanStrategy;
 import org.matsim.core.replanning.PlanStrategyImpl.Builder;
 import org.matsim.core.replanning.selectors.RandomPlanSelector;
 import org.matsim.core.router.TripRouter;
+import org.matsim.core.utils.timing.TimeInterpretation;
 import org.matsim.facilities.ActivityFacilities;
 
 import javax.inject.Inject;
@@ -36,11 +37,12 @@ public class RandomSingleTripReRoute implements Provider<PlanStrategy> {
 	@Inject private GlobalConfigGroup globalConfigGroup;
 	@Inject private ActivityFacilities facilities;
 	@Inject private Provider<TripRouter> tripRouterProvider;
+	@Inject private TimeInterpretation timeInterpretation;
 
 	@Override
 	public PlanStrategy get() {
 		Builder builder = new Builder(new RandomPlanSelector<Plan,Person>()) ;
-		builder.addStrategyModule(new RandomSingleTripReRouteModule(facilities, tripRouterProvider, globalConfigGroup));
+		builder.addStrategyModule(new RandomSingleTripReRouteModule(facilities, tripRouterProvider, globalConfigGroup, timeInterpretation));
 		return builder.build() ;
 	}
 

--- a/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripReRouteModule.java
+++ b/src/main/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripReRouteModule.java
@@ -28,6 +28,7 @@ import org.matsim.core.gbl.MatsimRandom;
 import org.matsim.core.population.algorithms.PlanAlgorithm;
 import org.matsim.core.replanning.modules.AbstractMultithreadedModule;
 import org.matsim.core.router.TripRouter;
+import org.matsim.core.utils.timing.TimeInterpretation;
 import org.matsim.facilities.ActivityFacilities;
 
 /**
@@ -41,11 +42,13 @@ public class RandomSingleTripReRouteModule extends AbstractMultithreadedModule {
 	private ActivityFacilities facilities;
 
 	private final Provider<TripRouter> tripRouterProvider;
+	private TimeInterpretation timeInterpretation;
 
-	public RandomSingleTripReRouteModule(ActivityFacilities facilities, Provider<TripRouter> tripRouterProvider, GlobalConfigGroup globalConfigGroup) {
+	public RandomSingleTripReRouteModule(ActivityFacilities facilities, Provider<TripRouter> tripRouterProvider, GlobalConfigGroup globalConfigGroup, TimeInterpretation timeInterpretation) {
 		super(globalConfigGroup);
 		this.facilities = facilities;
 		this.tripRouterProvider = tripRouterProvider;
+		this.timeInterpretation = timeInterpretation;
 	}
 
 	@Override
@@ -53,7 +56,8 @@ public class RandomSingleTripReRouteModule extends AbstractMultithreadedModule {
 			return new RandomSingleTripPlanRouter(
 					tripRouterProvider.get(),
 					facilities,
-					MatsimRandom.getLocalInstance());
+					MatsimRandom.getLocalInstance(),
+					timeInterpretation);
 	}
 
 }

--- a/src/main/java/org/matsim/extensions/pt/routing/EnhancedRaptorIntermodalAccessEgress.java
+++ b/src/main/java/org/matsim/extensions/pt/routing/EnhancedRaptorIntermodalAccessEgress.java
@@ -128,7 +128,7 @@ public class EnhancedRaptorIntermodalAccessEgress implements RaptorIntermodalAcc
 
 						}
 
-						fare += drtFareParams.getBasefare();
+						fare += drtFareParams.getBaseFare();
 						fare = Math.max(fare, drtFareParams.getMinFarePerTrip());
 						utility += -1. * fare * marginalUtilityOfMoney;
 					}

--- a/src/main/java/org/matsim/extensions/pt/routing/ptRoutingModes/PtRoutingModeWrapper.java
+++ b/src/main/java/org/matsim/extensions/pt/routing/ptRoutingModes/PtRoutingModeWrapper.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import org.matsim.api.core.v01.population.Person;
 import org.matsim.api.core.v01.population.PlanElement;
 import org.matsim.core.router.RoutingModule;
+import org.matsim.core.router.RoutingRequest;
 import org.matsim.facilities.Facility;
 import org.matsim.extensions.pt.routing.ptRoutingModes.PtIntermodalRoutingModesConfigGroup.PersonAttribute2ValuePair;
 import org.matsim.extensions.pt.routing.ptRoutingModes.PtIntermodalRoutingModesConfigGroup.PtIntermodalRoutingModeParameterSet;
@@ -47,17 +48,16 @@ class PtRoutingModeWrapper implements RoutingModule {
 	}
 
 	@Override
-	public List<? extends PlanElement> calcRoute(Facility fromFacility, Facility toFacility, double departureTime,
-			Person person) {
+	public List<? extends PlanElement> calcRoute(RoutingRequest request) {
 		for (PersonAttribute2ValuePair personAttribute2ValuePair: personAttribute2ValuePairs) {
-			person.getAttributes().putAttribute(personAttribute2ValuePair.getPersonFilterAttribute(), 
+			request.getPerson().getAttributes().putAttribute(personAttribute2ValuePair.getPersonFilterAttribute(),
 					personAttribute2ValuePair.getPersonFilterValue());
 		}
 
-		List<? extends PlanElement> route = ptRouter.calcRoute(fromFacility, toFacility, departureTime, person);
+		List<? extends PlanElement> route = ptRouter.calcRoute(request);
 		
 		for (PersonAttribute2ValuePair personAttribute2ValuePair: personAttribute2ValuePairs) {
-			person.getAttributes().removeAttribute(personAttribute2ValuePair.getPersonFilterAttribute());
+			request.getPerson().getAttributes().removeAttribute(personAttribute2ValuePair.getPersonFilterAttribute());
 		}
 		
 		return route;

--- a/src/test/java/org/matsim/extensions/pt/fare/intermodalTripFareCompensator/IntermodalTripFareCompensatorPerTripTest.java
+++ b/src/test/java/org/matsim/extensions/pt/fare/intermodalTripFareCompensator/IntermodalTripFareCompensatorPerTripTest.java
@@ -36,6 +36,7 @@ import org.matsim.api.core.v01.population.Person;
 import org.matsim.core.config.Config;
 import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.events.ParallelEventsManager;
+import org.matsim.core.router.DefaultRoutingRequest;
 import org.matsim.facilities.ActivityFacility;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -103,15 +104,15 @@ public class IntermodalTripFareCompensatorPerTripTest {
         Id<Person> personId1 = Id.createPersonId("p1");
 
         // test trip with drt mode but not intermodal
-        events.processEvent(new PersonDepartureEvent(0.0, personId1, Id.createLinkId("12"), TransportMode.drt));
+        events.processEvent(new PersonDepartureEvent(0.0, personId1, Id.createLinkId("12"), TransportMode.drt, TransportMode.drt));
         events.processEvent(new ActivityStartEvent(1.0, personId1, Id.createLinkId("23"), Id.create("dummy", ActivityFacility.class), "work"));
         events.flush();
         Assert.assertTrue("Compensation money should be 0, but is not!", person2Fare.get(personId1) == null);
         Assert.assertTrue("Compensation should be 0, but is not!", person2Score.get(personId1) == null);
         
         // test intermodal trip without drt mode (only unrelated other mode)
-        events.processEvent(new PersonDepartureEvent(2.0, personId1, Id.createLinkId("23"), TransportMode.car));
-        events.processEvent(new PersonDepartureEvent(3.0, personId1, Id.createLinkId("34"), TransportMode.pt));
+        events.processEvent(new PersonDepartureEvent(2.0, personId1, Id.createLinkId("23"), TransportMode.car, TransportMode.pt));
+        events.processEvent(new PersonDepartureEvent(3.0, personId1, Id.createLinkId("34"), TransportMode.pt, TransportMode.pt));
         
         // there should be no compensation so far
         events.flush();
@@ -119,7 +120,7 @@ public class IntermodalTripFareCompensatorPerTripTest {
         Assert.assertTrue("Compensation score should be 0, but is not!", person2Score.get(personId1) == null);
 
         // test drt after pt leg
-        events.processEvent(new PersonDepartureEvent(4.0, personId1, Id.createLinkId("45"), TransportMode.drt));
+        events.processEvent(new PersonDepartureEvent(4.0, personId1, Id.createLinkId("45"), TransportMode.drt, TransportMode.drt));
         
         // compensation paid once
         events.flush();
@@ -127,7 +128,7 @@ public class IntermodalTripFareCompensatorPerTripTest {
         Assert.assertEquals("After a pt and a drt leg compensation score should be paid once, but is not", 1 * compensationScorePerTrip, person2Score.get(personId1), MatsimTestUtils.EPSILON);
 
         // some distraction, nothing should change
-        events.processEvent(new PersonDepartureEvent(4.0, personId1, Id.createLinkId("45"), TransportMode.pt));
+        events.processEvent(new PersonDepartureEvent(4.0, personId1, Id.createLinkId("45"), TransportMode.pt, TransportMode.pt));
 		
 	    // compensation paid once
         events.flush();
@@ -139,9 +140,9 @@ public class IntermodalTripFareCompensatorPerTripTest {
         events.processEvent(new ActivityStartEvent(5.0, personId1, Id.createLinkId("23"), Id.create("dummy", ActivityFacility.class), "blub"));
         
         // test drt2 before pt with interaction activity in between
-        events.processEvent(new PersonDepartureEvent(6.0, personId1, Id.createLinkId("45"), "drt2"));
+        events.processEvent(new PersonDepartureEvent(6.0, personId1, Id.createLinkId("45"), "drt2", TransportMode.pt));
         events.processEvent(new ActivityStartEvent(7.0, personId1, Id.createLinkId("56"), Id.create("dummy", ActivityFacility.class), "drt interaction"));
-        events.processEvent(new PersonDepartureEvent(8.0, personId1, Id.createLinkId("56"), TransportMode.pt));
+        events.processEvent(new PersonDepartureEvent(8.0, personId1, Id.createLinkId("56"), TransportMode.pt, TransportMode.pt));
         
         // compensation paid second time (second trip)
         events.flush();
@@ -149,12 +150,12 @@ public class IntermodalTripFareCompensatorPerTripTest {
         Assert.assertEquals("After a drt2 and a pt leg compensation score should be paid a 2nd time, but is not", 2 * compensationScorePerTrip, person2Score.get(personId1), MatsimTestUtils.EPSILON);
 
         // some distraction, nothing should change
-        events.processEvent(new PersonDepartureEvent(4.0, personId1, Id.createLinkId("45"), TransportMode.pt));
+        events.processEvent(new PersonDepartureEvent(4.0, personId1, Id.createLinkId("45"), TransportMode.pt, TransportMode.pt));
         events.flush();
         Assert.assertEquals("After a drt2 and a pt leg compensation money should be paid a 2nd time, but is not", 2 * compensationMoneyPerTrip, person2Fare.get(personId1), MatsimTestUtils.EPSILON);
         Assert.assertEquals("After a drt2 and a pt leg compensation score should be paid a 2nd time, but is not", 2 * compensationScorePerTrip, person2Score.get(personId1), MatsimTestUtils.EPSILON);
 
-        events.processEvent(new PersonDepartureEvent(4.0, personId1, Id.createLinkId("67"), TransportMode.drt));
+        events.processEvent(new PersonDepartureEvent(4.0, personId1, Id.createLinkId("67"), TransportMode.drt, TransportMode.pt));
         
         // compensation paid third time (second trip)
         events.flush();
@@ -163,9 +164,9 @@ public class IntermodalTripFareCompensatorPerTripTest {
 
         Id<Person> personId2 = Id.createPersonId("p2");
         // test drt before pt with interaction activity in between at other agent who did not use pt before
-        events.processEvent(new PersonDepartureEvent(6.0, personId2, Id.createLinkId("45"), "drt"));
+        events.processEvent(new PersonDepartureEvent(6.0, personId2, Id.createLinkId("45"), "drt", TransportMode.pt));
         events.processEvent(new ActivityStartEvent(7.0, personId2, Id.createLinkId("56"), Id.create("dummy", ActivityFacility.class), "drt interaction"));
-        events.processEvent(new PersonDepartureEvent(8.0, personId2, Id.createLinkId("56"), TransportMode.pt));
+        events.processEvent(new PersonDepartureEvent(8.0, personId2, Id.createLinkId("56"), TransportMode.pt, TransportMode.pt));
         events.flush();
         Assert.assertEquals("After a pt and a drt leg compensation money should be paid once, but is not", 1 * compensationMoneyPerTrip, person2Fare.get(personId2), MatsimTestUtils.EPSILON);
         Assert.assertEquals("After a pt and a drt leg compensation score should be paid once, but is not", 1 * compensationScorePerTrip, person2Score.get(personId2), MatsimTestUtils.EPSILON);

--- a/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRoutePlanRouterTest.java
+++ b/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRoutePlanRouterTest.java
@@ -35,6 +35,7 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Injector;
 import org.matsim.core.gbl.MatsimRandom;
+import org.matsim.core.router.PlanRouter;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripRouterModule;
 import org.matsim.core.router.TripStructureUtils;
@@ -72,6 +73,10 @@ public class ChangeSingleTripModeAndRoutePlanRouterTest {
             }
         });
         TripRouter tripRouter = injector.getInstance(TripRouter.class);
+        TimeInterpretation timeInterpretation = TimeInterpretation.create(config);
+        PlanRouter planRouter = new PlanRouter(tripRouter, timeInterpretation);
+
+        scenario.getPopulation().getPersons().values().stream().forEach(person -> planRouter.run(person));
 		
         int carTripsBefore = 0;
         Plan plan = scenario.getPopulation().getPersons().get(Id.createPersonId(1)).getSelectedPlan();
@@ -84,8 +89,8 @@ public class ChangeSingleTripModeAndRoutePlanRouterTest {
         	}
         }
         
-		ChangeSingleTripModeAndRoutePlanRouter planRouter = new ChangeSingleTripModeAndRoutePlanRouter(tripRouter, null, MatsimRandom.getRandom(), config.changeMode(), TimeInterpretation.create(config));
-		planRouter.run(plan);
+		ChangeSingleTripModeAndRoutePlanRouter changeSingleTripModeAndRoutePlanRouter = new ChangeSingleTripModeAndRoutePlanRouter(tripRouter, null, MatsimRandom.getRandom(), config.changeMode(), TimeInterpretation.create(config));
+        changeSingleTripModeAndRoutePlanRouter.run(plan);
 		
     	System.out.println("----");
 		

--- a/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRoutePlanRouterTest.java
+++ b/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRoutePlanRouterTest.java
@@ -45,6 +45,7 @@ import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.timing.TimeInterpretation;
+import org.matsim.core.utils.timing.TimeInterpretationModule;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -64,6 +65,7 @@ public class ChangeSingleTripModeAndRoutePlanRouterTest {
             @Override
             public void install() {
                 install(new TripRouterModule());
+                install(new TimeInterpretationModule());
                 install(new ScenarioByInstanceModule(scenario));
                 addTravelTimeBinding("car").toInstance(new FreespeedTravelTimeAndDisutility(config.planCalcScore()));
                 addTravelDisutilityFactoryBinding("car").toInstance(new OnlyTimeDependentTravelDisutilityFactory());

--- a/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRoutePlanRouterTest.java
+++ b/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/ChangeSingleTripModeAndRoutePlanRouterTest.java
@@ -44,6 +44,7 @@ import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutilityF
 import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.io.IOUtils;
+import org.matsim.core.utils.timing.TimeInterpretation;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -81,7 +82,7 @@ public class ChangeSingleTripModeAndRoutePlanRouterTest {
         	}
         }
         
-		ChangeSingleTripModeAndRoutePlanRouter planRouter = new ChangeSingleTripModeAndRoutePlanRouter(tripRouter, null, MatsimRandom.getRandom(), config.changeMode());     
+		ChangeSingleTripModeAndRoutePlanRouter planRouter = new ChangeSingleTripModeAndRoutePlanRouter(tripRouter, null, MatsimRandom.getRandom(), config.changeMode(), TimeInterpretation.create(config));
 		planRouter.run(plan);
 		
     	System.out.println("----");

--- a/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripPlanRouterTest.java
+++ b/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripPlanRouterTest.java
@@ -44,6 +44,7 @@ import org.matsim.core.router.costcalculators.OnlyTimeDependentTravelDisutilityF
 import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.io.IOUtils;
+import org.matsim.core.utils.timing.TimeInterpretation;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -82,7 +83,7 @@ public class RandomSingleTripPlanRouterTest {
         	}
         }
                 
-        RandomSingleTripPlanRouter singleTripPlanRouter = new RandomSingleTripPlanRouter(tripRouter, MatsimRandom.getLocalInstance());     
+        RandomSingleTripPlanRouter singleTripPlanRouter = new RandomSingleTripPlanRouter(tripRouter, MatsimRandom.getLocalInstance(), TimeInterpretation.create(config));
         singleTripPlanRouter.run(plan);
         
     	System.out.println("----");

--- a/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripPlanRouterTest.java
+++ b/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripPlanRouterTest.java
@@ -35,6 +35,7 @@ import org.matsim.core.config.ConfigUtils;
 import org.matsim.core.controler.AbstractModule;
 import org.matsim.core.controler.Injector;
 import org.matsim.core.gbl.MatsimRandom;
+import org.matsim.core.router.PlanRouter;
 import org.matsim.core.router.TripRouter;
 import org.matsim.core.router.TripRouterModule;
 import org.matsim.core.router.TripStructureUtils;
@@ -72,6 +73,10 @@ public class RandomSingleTripPlanRouterTest {
             }
         });
         TripRouter tripRouter = injector.getInstance(TripRouter.class);
+        TimeInterpretation timeInterpretation = TimeInterpretation.create(config);
+        PlanRouter planRouter = new PlanRouter(tripRouter, timeInterpretation);
+
+        scenario.getPopulation().getPersons().values().stream().forEach(person -> planRouter.run(person));
         
         Plan plan = scenario.getPopulation().getPersons().get(Id.createPersonId(1)).getSelectedPlan();
         int carTripsBefore = 0;

--- a/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripPlanRouterTest.java
+++ b/src/test/java/org/matsim/extensions/pt/replanning/singleTripStrategies/RandomSingleTripPlanRouterTest.java
@@ -45,6 +45,7 @@ import org.matsim.core.scenario.ScenarioByInstanceModule;
 import org.matsim.core.scenario.ScenarioUtils;
 import org.matsim.core.utils.io.IOUtils;
 import org.matsim.core.utils.timing.TimeInterpretation;
+import org.matsim.core.utils.timing.TimeInterpretationModule;
 import org.matsim.examples.ExamplesUtils;
 import org.matsim.testcases.MatsimTestUtils;
 
@@ -64,6 +65,7 @@ public class RandomSingleTripPlanRouterTest {
             @Override
             public void install() {
                 install(new TripRouterModule());
+				install(new TimeInterpretationModule());
                 install(new ScenarioByInstanceModule(scenario));
                 addTravelTimeBinding("car").toInstance(new FreespeedTravelTimeAndDisutility(config.planCalcScore()));
                 addTravelDisutilityFactoryBinding("car").toInstance(new OnlyTimeDependentTravelDisutilityFactory());

--- a/src/test/java/org/matsim/extensions/pt/routing/EnhancedRaptorIntermodalAccessEgressTest.java
+++ b/src/test/java/org/matsim/extensions/pt/routing/EnhancedRaptorIntermodalAccessEgressTest.java
@@ -106,7 +106,7 @@ public class EnhancedRaptorIntermodalAccessEgressTest {
 		DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
 		drtConfigGroup.setMode(TransportMode.drt);
 		DrtFareParams drtFareParams = new DrtFareParams();
-		drtFareParams.setBasefare(1.0);
+		drtFareParams.setBaseFare(1.0);
 		drtFareParams.setDailySubscriptionFee(10.0);
 		drtFareParams.setMinFarePerTrip(2.0);
 		drtFareParams.setDistanceFare_m(0.0002);
@@ -406,7 +406,7 @@ public class EnhancedRaptorIntermodalAccessEgressTest {
 		DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
 		drtConfigGroup.setMode(TransportMode.drt);
 		DrtFareParams drtFareParams = new DrtFareParams();
-		drtFareParams.setBasefare(1.0);
+		drtFareParams.setBaseFare(1.0);
 		drtFareParams.setDailySubscriptionFee(10.0);
 		drtFareParams.setMinFarePerTrip(2.0);
 		drtFareParams.setDistanceFare_m(0.0002);
@@ -500,7 +500,7 @@ public class EnhancedRaptorIntermodalAccessEgressTest {
 		DrtConfigGroup drtConfigGroup = new DrtConfigGroup();
 		drtConfigGroup.setMode(TransportMode.drt);
 		DrtFareParams drtFareParams = new DrtFareParams();
-		drtFareParams.setBasefare(1.0);
+		drtFareParams.setBaseFare(1.0);
 		drtFareParams.setDailySubscriptionFee(10.0);
 		drtFareParams.setMinFarePerTrip(2.0);
 		drtFareParams.setDistanceFare_m(0.0002);


### PR DESCRIPTION
In MATSim [PR #1682](https://github.com/matsim-org/matsim-libs/pull/1682), @luchengqi7 changed the syntax of the config setter and getter for the drt base fare. That led to a conflict when i wanted to update the matsim version in the the Hamburg project. So I would like to update the matsim version for the pt-extensions, too.

Now, there were more structural changes in the meantime. Important to note here are the following:

1.  [MATSim PR #1629](https://github.com/matsim-org/matsim-libs/pull/1629)
2.  [MATSim PR #1626](https://github.com/matsim-org/matsim-libs/pull/1626)
3.  changes to the PersonDepartureEvent, which now needs a routingMode

I edited such that no compilation errors occur. I checked on a few tests locally - let us see if they all run through.
Especially for the `IntermodalTripFareCompensatorPerTripTest` i am not really certain, if i put in the correct routingMode. @vsp-gleich could you please check?

Another thing that i am uncertain about is, whether we should set `oldTrip.getTripAttributes()` or `oldTrip.getOriginActivity().getAttributes()` as routing attributes when re-routing a trip. When @sebhoerl did the structural change, he put in the latter.
